### PR TITLE
fix weak parameter and add remove paths function

### DIFF
--- a/src/static_sox/__init__.py
+++ b/src/static_sox/__init__.py
@@ -2,4 +2,6 @@
 Init.
 """
 
-from ._add_paths import add_paths
+from ._add_paths import add_paths, remove_paths
+
+__all__ = ["add_paths", "remove_paths"]

--- a/src/static_sox/_add_paths.py
+++ b/src/static_sox/_add_paths.py
@@ -1,5 +1,6 @@
 """
-add_paths() Adds ffmpeg and ffprobe to the path, overriding any system ffmpeg/ffprobe.
+add_paths() Adds sox to the path, overriding any system sox.
+remove_paths() Removes sox from the path.
 """
 
 import os
@@ -14,11 +15,38 @@ def _has(name: str) -> bool:
 
 
 def add_paths(weak=False) -> bool:
-    """Add the ffmpeg executable to the path"""
-    if weak:
-        has_sox = _has("sox") is not None
-        if has_sox:
-            return False
+    """Add the sox executable to the path"""
+    if weak and _has("sox"):
+        return False
     sox_exe = get_or_fetch_platform_executables_else_raise()
     os.environ["PATH"] = os.pathsep.join([os.path.dirname(sox_exe), os.environ["PATH"]])
     return True
+
+
+def remove_paths() -> None:
+    """Remove the sox executable from the path"""
+    sox_exe = get_or_fetch_platform_executables_else_raise()
+    install_dir = os.path.dirname(sox_exe)
+    os.environ["PATH"] = os.pathsep.join(
+        [x for x in os.environ["PATH"].split(os.pathsep) if x != install_dir]
+    )
+    # NOTE in addition to adding sox to the PATH variable, add_paths()
+    # also sets the LD_PRELOAD variable to include all the dependencies
+    # of the sox executable. We remove these dependencies from the
+    # LD_PRELOAD variable below.
+    deps = [
+        "libbz2.so.1.0",
+        "libgomp.so.1",
+        "libgsm.so.1",
+        "libltdl.so.7",
+        "liblzma.so.5",
+        "libm.so.6",
+        "libmagic.so.1",
+        "libpng16.so.16",
+        "libpthread.so.0",
+        "libsox.so.3",
+        "libz.so.1",
+    ]
+    os.environ["LD_PRELOAD"] = os.pathsep.join(
+        [x for x in os.environ.get("LD_PRELOAD", "").split(os.pathsep) if x not in deps]
+    )


### PR DESCRIPTION
This PR addresses https://github.com/zackees/static-sox/issues/2. Additionally, this PR also adds a `remove_from_path` function which removes the entries that `add_to_paths` adds to the `PATH` and `LD_PRELOAD` environment variables